### PR TITLE
Random seed support

### DIFF
--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -4,6 +4,7 @@ from .jinja import DPJinja
 from .magicprompt import DPMagicPrompt
 from .output_node import OutputString
 from .random import DPRandomGenerator
+from .string import DPMultilineString
 
 NODE_CLASS_MAPPINGS = {
     "DPRandomGenerator": DPRandomGenerator,
@@ -12,6 +13,7 @@ NODE_CLASS_MAPPINGS = {
     "DPJinja": DPJinja,
     "DPMagicPrompt": DPMagicPrompt,
     "DPOutput": OutputString,
+    "DPMultilineString": DPMultilineString,
 }
 
 # A dictionary that contains the friendly/humanly readable titles for the nodes
@@ -22,6 +24,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DPJinja": "Jinja2 Templates",
     "DPMagicPrompt": "Magic Prompt",
     "DPOutput": "OutputString",
+    "DPMultilineString": "Multiline String",
 }
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/nodes/feeling_lucky.py
+++ b/nodes/feeling_lucky.py
@@ -4,8 +4,8 @@ from .generator import DPGeneratorNode
 
 
 class DPFeelingLucky(DPGeneratorNode):
-    def generate_prompt(self, text) -> str:
-        prompt_generator = FeelingLuckyGenerator(generator=RandomPromptGenerator())
+    def generate_prompt(self, text, seed) -> str:
+        prompt_generator = FeelingLuckyGenerator(generator=RandomPromptGenerator(seed=seed))
 
         all_prompts = prompt_generator.generate(text, 1) or [""]
         return all_prompts[0]

--- a/nodes/generator.py
+++ b/nodes/generator.py
@@ -10,23 +10,24 @@ class DPGeneratorNode(ABC):
     def INPUT_TYPES(s):
         return {
             "required": {
-                "text": ("PROMPT", {"multiline": True}),
-                "autorefresh": (["Yes", "No"],),
+                "text": ("STRING", {"multiline": True, "dynamicPrompts": False}),
+                "seed": ("INT", {"default": 0, "display": "number"}),
+                "autorefresh": (["Yes", "No"], {"default": "No"}),
             },
         }
 
     @classmethod
-    def IS_CHANGED(cls, text, autorefresh):
+    def IS_CHANGED(cls, text, seed, autorefresh):
         # Force re-evaluation of the node
         if autorefresh == "Yes":
             return float("NaN")
 
-    def get_prompt(self, text: str, autorefresh: str) -> tuple[str]:
-        prompt = self.generate_prompt(text)
+    def get_prompt(self, text: str, seed: int, autorefresh: str) -> tuple[str]:
+        prompt = self.generate_prompt(text, seed)
         print(f"Prompt: {prompt}")
 
         return (prompt,)
 
     @abstractmethod
-    def generate_prompt(self, text: str) -> str:
+    def generate_prompt(self, text: str, seed: int) -> str:
         ...

--- a/nodes/jinja.py
+++ b/nodes/jinja.py
@@ -4,7 +4,8 @@ from .generator import DPGeneratorNode
 
 
 class DPJinja(DPGeneratorNode):
-    def generate_prompt(self, text):
+    def generate_prompt(self, text, seed):
+        # TODO: Add seed support
         prompt_generator = JinjaGenerator()
 
         all_prompts = prompt_generator.generate(text, 1) or [""]

--- a/nodes/magicprompt.py
+++ b/nodes/magicprompt.py
@@ -5,9 +5,9 @@ from .generator import DPGeneratorNode
 
 
 class DPMagicPrompt(DPGeneratorNode):
-    def generate_prompt(self, text):
+    def generate_prompt(self, text, seed):
         prompt_generator = MagicPromptGenerator(
-            prompt_generator=RandomPromptGenerator(),
+            prompt_generator=RandomPromptGenerator(seed=seed),
         )
 
         all_prompts = prompt_generator.generate(text, 1) or [""]

--- a/nodes/random.py
+++ b/nodes/random.py
@@ -1,16 +1,11 @@
-from functools import lru_cache
+from dynamicprompts.generators import RandomPromptGenerator
 
-from dynamicprompts.enums import SamplingMethod
-from dynamicprompts.sampling_context import SamplingContext
-
-from .sampler import DPAbstractSamplerNode
+from .generator import DPGeneratorNode
 
 
-class DPRandomGenerator(DPAbstractSamplerNode):
-    @property
-    @lru_cache(maxsize=1)
-    def context(self) -> SamplingContext:
-        return SamplingContext(
-            wildcard_manager=self._wildcard_manager,
-            default_sampling_method=SamplingMethod.RANDOM,
-        )
+class DPRandomGenerator(DPGeneratorNode):
+    def generate_prompt(self, text, seed) -> tuple[str]:
+        prompt_generator = RandomPromptGenerator(seed=seed)
+
+        all_prompts = prompt_generator.generate(text, 1) or [""]
+        return all_prompts[0]

--- a/nodes/string.py
+++ b/nodes/string.py
@@ -1,0 +1,17 @@
+class DPMultilineString:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "string": ("STRING", {"multiline": True, "dynamicPrompts": False}),
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "run"
+    CATEGORY = "Dynamic Prompts"
+
+    CATEGORY = "utils"
+
+    def run(self, string) -> tuple[str]:
+        return (string,)


### PR DESCRIPTION
Finally we get reproducible workflows!

Changes:
- add `seed` field to generators
- change `DPRandomGenerator` to inherit from `DPGeneratorNode`
- Autorefresh is disabled by default since `seed` makes the result fully deterministic when arguments are the same (unless some underlying wildcard files change
- add `DPMultilineString` node that passes string as is without applying dynamicPrompts to it
- change `PROMPT` input time to `STRING` so that the text widget can be converted into input (intended for use with `DPMultilineString` for example)

Caveats:
- I'm new to modding ComfyUI so could mess up in the code
- `DPJinja` has seed input but ignores it at the moment
- I don't understand what is special about `PROMPT` and what unforeseen consequences it could have when I changed it to `STRING`
- I didn't update any docs/examples (and to lazy too do it, so maybe someone else can handle that)

As an offtopic, I see "view prompt" item in your to do list. There is a working implementation in [Custom Scripts](https://github.com/pythongosssss/ComfyUI-Custom-Scripts/blob/main/py/show_text.py) plugin but it involves some JS hacks