### PR TITLE
Set seed min and max to match other nodes

### DIFF
--- a/nodes/sampler.py
+++ b/nodes/sampler.py
@@ -17,7 +17,7 @@ class DPAbstractSamplerNode(ABC):
         return {
             "required": {
                 "text": ("STRING", {"multiline": True, "dynamicPrompts": False}),
-                "seed": ("INT", {"default": 0, "display": "number"}),
+                "seed": ("INT", {"default": 0, "display": "number", "min": 0, "max": 0xffffffffffffffff}),
                 "autorefresh": (["Yes", "No"], {"default": "No"}),
             },
         }


### PR DESCRIPTION
This matches other nodes that have a seed value, for example the KSampler at https://github.com/comfyanonymous/ComfyUI/blob/master/nodes.py#L1357

This fixes the seed getting stuck at max 2048 in increment mode, or always returning a value <= 2048 in randomize mode.

Repro steps:
- create a "Random Prompts" node
- set the seed value to 3000 and control_after_generate to increment
- Queue Prompt
- notice that the seed resets to 2048
