### PR TITLE
Prevent reeval if nothing changed

### DIFF
--- a/nodes/random.py
+++ b/nodes/random.py
@@ -14,3 +14,8 @@ class DPRandomGenerator(DPAbstractSamplerNode):
             wildcard_manager=self._wildcard_manager,
             default_sampling_method=SamplingMethod.RANDOM,
         )
+
+    @classmethod
+    def IS_CHANGED(cls, text: str, seed: int, autorefresh: str):
+        # Force re-evaluation of the node only when something has changed
+        return f'[{text}, {seed}, {autorefresh}]'


### PR DESCRIPTION
I use the Random Prompt generator to have the same random prompt in all of my CLIPs, but there was a bug for the node, where it would always unconditionally recompute, which meant that when adding tiny things to a heavy compute graph, it took forever, rather than an eyeblink.

This change will only force recompute if the text, seed, or autorefresh properties change.

Since I don't truly understand the other nodes, this is just for the one I use.